### PR TITLE
feat: polish slide-in menu UX and add search pill to Active Filters

### DIFF
--- a/client/src/components/ColorfulBar.tsx
+++ b/client/src/components/ColorfulBar.tsx
@@ -35,7 +35,7 @@ export const ColorfulBar: React.FC = () => {
   // For black-and-white theme, show a simple black bar
   if (currentTheme === 'black-and-white') {
     return (
-      <div className="fixed top-0 left-0 w-full h-3 bg-black z-50">
+      <div className="fixed top-0 left-0 w-full h-4 bg-black z-50">
         {/* Simple black bar for black-white theme */}
       </div>
     );
@@ -43,7 +43,7 @@ export const ColorfulBar: React.FC = () => {
   
   // For all other themes (light, dark, sepia, system), show the colorful bar
   return (
-    <div className="fixed top-0 left-0 w-full h-3 bg-gradient-to-r from-[#01A5E1] via-[#0DD1EE] via-[#F5DA6C] via-[#285CC4] via-[#A7E459] to-[#E45093] z-50">
+    <div className="fixed top-0 left-0 w-full h-4 bg-gradient-to-r from-[#01A5E1] via-[#0DD1EE] via-[#F5DA6C] via-[#285CC4] via-[#A7E459] to-[#E45093] z-50">
       {/* Individual color segments for precise control */}
       <div className="flex h-full">
         <div className="flex-1 bg-[#01A5E1]"></div>

--- a/client/src/components/ContractStats.tsx
+++ b/client/src/components/ContractStats.tsx
@@ -1,11 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Contract, ContractFilters as FilterType } from '@/types/contract';
-import { ContractFilters } from '@/components/ContractFilters';
-import { isValidCategory, getCategoryStatsColor } from '@/lib/utils';
-import { useIsMobile } from '@/hooks/use-mobile';
+import { getCategoryStatsColor } from '@/lib/utils';
 import { getCategories } from '@/config/categories';
 import { 
   Calendar, 
@@ -13,9 +10,7 @@ import {
   AlertTriangle, 
   DollarSign, 
   Tag, 
-  Coins, 
-  Building2,
-  User
+  Coins
 } from 'lucide-react';
 
 interface ContractStatsProps {
@@ -46,58 +41,7 @@ export const ContractStats = ({
   availableTags,
   filteredContracts
 }: ContractStatsProps) => {
-  const [activeTab, setActiveTab] = useState('quickFilters');
-
-  const handleTabChange = (newTab: string) => {
-    setActiveTab(newTab);
-    // Reset filters when switching to advanced filters tab
-    if (newTab === 'filters' && onFilter) {
-      onFilter('reset', '');
-    }
-    // Reset filters when switching to persons tab
-    if (newTab === 'persons' && onFilter) {
-      onFilter('reset', '');
-    }
-    // Reset filters when switching to companies tab
-    if (newTab === 'companies' && onFilter) {
-      onFilter('reset', '');
-    }
-  };
   const activeContracts = contracts.filter(c => c.status === 'active');
-  const isMobile = useIsMobile();
-
-  // Helper function to get tab label and icon based on screen size
-  const getTabContent = (tabType: string) => {
-    if (isMobile) {
-      // Mobile: Show only icons
-      switch (tabType) {
-        case 'quickFilters':
-          return { icon: Tag, label: 'Quick' };
-        case 'companies':
-          return { icon: Building2, label: 'Company' };
-        case 'persons':
-          return { icon: User, label: 'Person' };
-        case 'filters':
-          return { icon: TrendingUp, label: 'Filters' };
-        default:
-          return { icon: Tag, label: tabType };
-      }
-    } else {
-      // Desktop: Show full text
-      switch (tabType) {
-        case 'quickFilters':
-          return { icon: Tag, label: 'Quick Filters' };
-        case 'companies':
-          return { icon: Building2, label: 'Show by Company' };
-        case 'persons':
-          return { icon: User, label: 'Show by Person' };
-        case 'filters':
-          return { icon: TrendingUp, label: 'Advanced Filters' };
-        default:
-          return { icon: Tag, label: tabType };
-      }
-    }
-  };
 
   type StatItem = {
     title: string;
@@ -111,109 +55,7 @@ export const ContractStats = ({
     tooltip?: string;
   };
 
-  const generateCategoryStats = (): StatItem[] => {
-    // Use actual available categories from config instead of hardcoded list
-    // This fixes the issue where contracts with categories like 'rent' wouldn't show up
-    // in the dashboard because they weren't in the hardcoded category list
-    const categories = getCategories();
-    
-    // Map categories to appropriate icons
-    const categoryIcons: Record<string, React.ComponentType<any>> = {
-      subscription: Coins,
-      insurance: AlertTriangle,
-      utilities: DollarSign,
-      rent: Building2,
-      house: Building2,
-      services: Tag,
-      software: TrendingUp,
-      maintenance: TrendingUp,
-      other: Tag,
-      marketing: TrendingUp,
-      internet: Building2,
-      phone: Building2,
-      gym: Building2,
-      streaming: Building2,
-      transportation: Building2,
-      food: Building2,
-      entertainment: Building2,
-      education: Building2,
-      healthcare: Building2,
-      legal: Building2,
-    };
 
-    return categories.map(category => {
-      const count = contracts.filter(c => c.category === category).length;
-      const Icon = categoryIcons[category] || Tag; // Default to Tag icon for unknown categories
-      const { color, bgColor } = getCategoryStatsColor(category);
-      
-      return {
-        title: category.charAt(0).toUpperCase() + category.slice(1),
-        value: count,
-        icon: Icon,
-        color,
-        bgColor,
-        clickable: count > 0,
-        filterType: 'category',
-        filterValue: category
-      };
-    });
-  };
-
-  const generateFamilyMemberStats = (): StatItem[] => {
-    // Extract unique family members from contracts
-    const familyMembers = new Set<string>();
-    contracts.forEach(contract => {
-      if (contract.familyMember?.trim()) {
-        familyMembers.add(contract.familyMember.trim());
-      }
-    });
-
-    return Array.from(familyMembers)
-      .map(member => {
-        // Count contracts with trimmed family member names for accurate counting
-        const count = contracts.filter(c => c.familyMember?.trim() === member).length;
-        return {
-          title: member,
-          value: count,
-          icon: User, // Using User icon for family members
-          color: 'text-purple-600 dark:text-purple-400',
-          bgColor: 'bg-purple-100 dark:bg-purple-900/30',
-          clickable: count > 0,
-          filterType: 'familyMember',
-          filterValue: member
-        };
-      })
-      .sort((a, b) => (b.value as number) - (a.value as number)); // Sort by count descending
-  };
-
-  const generateCompanyStats = (): StatItem[] => {
-    // Extract unique companies from contracts
-    const companies = new Set<string>();
-    contracts.forEach(contract => {
-      if (contract.company?.trim()) {
-        companies.add(contract.company.trim());
-      }
-    });
-
-
-
-    return Array.from(companies)
-      .map(company => {
-        // Count contracts with trimmed company names for accurate counting
-        const count = contracts.filter(c => c.company?.trim() === company).length;
-        return {
-          title: company,
-          value: count,
-          icon: Building2, // Using Building2 icon for companies
-          color: 'text-blue-600 dark:text-blue-400',
-          bgColor: 'bg-blue-100 dark:bg-blue-900/30',
-          clickable: count > 0,
-          filterType: 'company',
-          filterValue: company
-        };
-      })
-      .sort((a, b) => (b.value as number) - (a.value as number)); // Sort by count descending
-  };
 
   const stats: StatItem[] = [
     {
@@ -275,8 +117,6 @@ export const ContractStats = ({
       bgColor: 'bg-green-100 dark:bg-green-900/30',
       clickable: false,
     },
-
-    ...generateCategoryStats(),
   ];
 
   // Helper function to render a compact stat card
@@ -318,195 +158,14 @@ export const ContractStats = ({
     );
   };
 
-  // Helper function to render a stat card
-  const renderStatCard = (stat: StatItem, index: number) => {
-    const isActive = activeFilters && (
-      (stat.filterType === 'viewMode' && (
-        (stat.filterValue === 'all' && !activeFilters.status && !activeFilters.needsMoreInfo) ||
-        (stat.filterValue === 'active' && activeFilters.status === 'active') ||
-        (stat.filterValue === 'needsAttention' && activeFilters.needsMoreInfo === true)
-      )) ||
-      (stat.filterType === 'category' && activeFilters.category === stat.filterValue) ||
-      (stat.filterType === 'pinned' && activeFilters.pinned === (stat.filterValue === 'true'))
-    );
-    
-    const cardContent = (
-      <Card 
-        key={`${stat.filterType}-${index}`}
-        className={`bg-gradient-card border-border/50 hover:shadow-card transition-all duration-300 animate-fade-in ${
-          stat.clickable && onFilter ? 'cursor-pointer hover:scale-105 border-primary/30 hover:border-primary/50' : ''
-        } ${isActive ? 'ring-2 ring-primary bg-primary/5 border-primary/50' : ''}`} 
-        style={{ animationDelay: `${index * 0.1}s` }}
-        onClick={stat.clickable && onFilter ? () => onFilter(stat.filterType!, stat.filterValue!) : undefined}
-      >
-        <CardContent className="p-2">
-          <div className="flex flex-col items-center text-center space-y-1">
-            <div className={`${stat.bgColor} p-1.5 rounded-lg mb-1`}>
-              <stat.icon className={`h-3.5 w-3.5 ${stat.color}`} />
-            </div>
-            <div className="flex items-center gap-1">
-              <p className="text-xs font-medium text-muted-foreground leading-tight">
-                {stat.title}
-              </p>
 
-            </div>
-            <p className="text-base font-bold text-foreground leading-tight">
-              {stat.value}
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-    );
-
-    // If the stat has a tooltip, wrap it with a tooltip
-    if (stat.tooltip) {
-      return (
-        <TooltipProvider key={`${stat.filterType}-${index}`}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {cardContent}
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{stat.tooltip}</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      );
-    }
-
-    return cardContent;
-  };
-
-  // Helper function to render compact category, family member, and company cards
-  const renderCategoryCard = (stat: StatItem, index: number) => {
-    const isActive = activeFilters && (
-      (stat.filterType === 'category' && activeFilters.category === stat.filterValue) ||
-      (stat.filterType === 'familyMember' && activeFilters.familyMember === stat.filterValue) ||
-      (stat.filterType === 'company' && activeFilters.company === stat.filterValue)
-    );
-    
-    return (
-      <Card 
-        key={`${stat.filterType}-${index}`}
-        className={`bg-gradient-card border-border/50 hover:shadow-card transition-all duration-200 ${
-          stat.clickable && onFilter ? 'cursor-pointer hover:scale-[1.02] border-primary/30 hover:border-primary/50' : ''
-        } ${isActive ? 'ring-2 ring-primary bg-primary/5 border-primary/50' : ''}`} 
-        onClick={stat.clickable && onFilter ? () => onFilter(stat.filterType!, stat.filterValue!) : undefined}
-      >
-        <CardContent className="p-2">
-          <div className="flex items-center gap-2">
-            <div className={`${stat.bgColor} p-1.5 rounded flex-shrink-0`}>
-              <stat.icon className={`h-3 w-3 ${stat.color}`} />
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-muted-foreground truncate">
-                  {stat.title}
-                </span>
-                <span className="text-xs font-bold text-foreground ml-1">
-                  {stat.value}
-                </span>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    );
-  };
 
   return (
     <div className="mb-4">
-      <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-        <TabsList className="grid w-full grid-cols-4 mb-4">
-          {(() => {
-            const quickFilters = getTabContent('quickFilters');
-            const companies = getTabContent('companies');
-            const persons = getTabContent('persons');
-            const filters = getTabContent('filters');
-            
-            return (
-              <>
-                <TabsTrigger value="quickFilters" className="text-xs sm:text-sm flex items-center gap-2">
-                  <quickFilters.icon className="h-4 w-4" />
-                  <span className="hidden sm:inline">{quickFilters.label}</span>
-                </TabsTrigger>
-                <TabsTrigger value="companies" className="text-xs sm:text-sm flex items-center gap-2">
-                  <companies.icon className="h-4 w-4" />
-                  <span className="hidden sm:inline">{companies.label}</span>
-                </TabsTrigger>
-                <TabsTrigger value="persons" className="text-xs sm:text-sm flex items-center gap-2">
-                  <persons.icon className="h-4 w-4" />
-                  <span className="hidden sm:inline">{persons.label}</span>
-                </TabsTrigger>
-                <TabsTrigger value="filters" className="text-xs sm:text-sm flex items-center gap-2">
-                  <filters.icon className="h-4 w-4" />
-                  <span className="hidden sm:inline">{filters.label}</span>
-                </TabsTrigger>
-              </>
-            );
-          })()}
-        </TabsList>
-        
-        <TabsContent value="quickFilters" className="space-y-3">
-          {/* Quick Filter - Categories Only */}
-          <div className="p-3 bg-muted/10 rounded-lg border border-border/30">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-sm font-medium text-foreground">Filter by Category</h3>
-              <span className="text-xs text-muted-foreground">Click to filter</span>
-            </div>
-            
-            {/* Categories Only */}
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2">
-              {stats.filter(stat => stat.filterType === 'category')
-                .filter(stat => typeof stat.value === 'number' && stat.value > 0)
-                .sort((a, b) => (b.value as number) - (a.value as number))
-                .map((stat, index) => renderCategoryCard(stat, index))}
-            </div>
-          </div>
-        </TabsContent>
-        
-        <TabsContent value="companies" className="space-y-3">
-          {/* Company Filter */}
-          <div className="p-3 bg-muted/10 rounded-lg border border-border/30">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-sm font-medium text-foreground">Filter by Company</h3>
-              <span className="text-xs text-muted-foreground">Click to filter</span>
-            </div>
-            
-            {/* Company Filter Buttons */}
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2">
-              {generateCompanyStats().map((stat, index) => renderCategoryCard(stat, index))}
-            </div>
-          </div>
-        </TabsContent>
-        
-        <TabsContent value="persons" className="space-y-3">
-          {/* Person Filter */}
-          <div className="p-3 bg-muted/10 rounded-lg border border-border/30">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-sm font-medium text-foreground">Filter by Person</h3>
-              <span className="text-xs text-muted-foreground">Click to filter</span>
-            </div>
-            
-            {/* Person Filter Buttons */}
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2">
-              {generateFamilyMemberStats().map((stat, index) => renderCategoryCard(stat, index))}
-            </div>
-          </div>
-        </TabsContent>
-        
-        <TabsContent value="filters" className="space-y-2">
-          {/* Advanced Filters Section */}
-          <div className="w-full">
-            <ContractFilters 
-              filters={filters} 
-              onFiltersChange={onFiltersChange} 
-              availableTags={availableTags}
-              existingContracts={contracts}
-            />
-          </div>
-        </TabsContent>
-      </Tabs>
+      {/* Overview Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 mb-4">
+        {stats.map((stat, index) => renderCompactStatCard(stat, index))}
+      </div>
     </div>
   );
 };

--- a/client/src/components/NotificationBanner.tsx
+++ b/client/src/components/NotificationBanner.tsx
@@ -31,9 +31,9 @@ export const NotificationBanner = ({ contracts, onEdit }: NotificationBannerProp
     })
     .sort((a, b) => a.daysUntil - b.daysUntil);
 
-  // Start collapsed if there are more than 3 upcoming payments
-  const [isUpcomingPaymentsExpanded, setIsUpcomingPaymentsExpanded] = useState(upcomingPayments.length <= 3);
-  const [isExpiredContractsExpanded, setIsExpiredContractsExpanded] = useState(true);
+  // Start collapsed by default to save space
+  const [isUpcomingPaymentsExpanded, setIsUpcomingPaymentsExpanded] = useState(false);
+  const [isExpiredContractsExpanded, setIsExpiredContractsExpanded] = useState(false);
 
   const expiredContracts = contracts.filter(c => c.status === 'expired');
 

--- a/client/src/components/SlideInMenu.tsx
+++ b/client/src/components/SlideInMenu.tsx
@@ -1,0 +1,652 @@
+import { useState, useRef, useEffect } from 'react';
+import { ContractFilters as FilterType, Contract } from '@/types/contract';
+import { getCategories, getCategoryDisplayName } from '@/config/categories';
+import { getStatuses, getStatusDisplayName } from '@/config/statuses';
+import { getFrequencies, getFrequencyDisplayName } from '@/config/frequencies';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { X, Menu, Search, Download, Upload, Plus, Settings, Tag, Building2, User, TrendingUp } from 'lucide-react';
+import { appConfig } from '@/config/app';
+import { ThemeToggle } from '@/components/ThemeToggle';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger, SheetPortal, SheetOverlay } from '@/components/ui/sheet';
+import { Separator } from '@/components/ui/separator';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Card, CardContent } from '@/components/ui/card';
+import { isValidCategory, getCategoryStatsColor } from '@/lib/utils';
+
+interface SlideInMenuProps {
+  filters: FilterType;
+  onFiltersChange: (filters: FilterType) => void;
+  availableTags?: string[];
+  existingContracts?: Contract[];
+  onExport: () => void;
+  onImport: () => void;
+  onAddContract: () => void;
+  contracts: Contract[];
+}
+
+export const SlideInMenu = ({ 
+  filters, 
+  onFiltersChange, 
+  availableTags = [], 
+  existingContracts = [],
+  onExport,
+  onImport,
+  onAddContract,
+  contracts
+}: SlideInMenuProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('quickFilters');
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus search input when sheet opens
+  useEffect(() => {
+    if (isOpen && searchInputRef.current) {
+      // Small delay to ensure the sheet is fully rendered
+      setTimeout(() => {
+        if (searchInputRef.current) {
+          searchInputRef.current.focus();
+        }
+      }, 200);
+    }
+  }, [isOpen]);
+
+  // Handle Ctrl+F keyboard shortcut to focus search
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Try both Ctrl+F and Cmd+F (Mac)
+      if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
+        // Only intercept when menu is closed
+        if (!isOpen) {
+          event.preventDefault();
+          event.stopPropagation();
+          setIsOpen(true);
+          setTimeout(() => {
+            searchInputRef.current?.focus();
+          }, 300);
+        }
+        // When menu is open, let browser handle Ctrl+F normally
+      }
+    };
+
+    // Always add event listener to document (use bubbling phase, not capture)
+    document.addEventListener('keydown', handleKeyDown, false);
+    
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, false);
+    };
+  }, [isOpen]);
+
+  const updateFilter = (key: keyof FilterType, value: any) => {
+    const newFilters = { ...filters, [key]: value };
+    onFiltersChange(newFilters);
+  };
+
+  const clearFilter = (key: keyof FilterType) => {
+    updateFilter(key, undefined);
+  };
+
+  const clearAllFilters = () => {
+    onFiltersChange({
+      searchTerm: '',
+      status: undefined,
+      category: undefined,
+      company: undefined,
+      frequency: undefined,
+      tags: undefined,
+      needsMoreInfo: undefined,
+      pinned: undefined,
+      hasAdditionalFields: undefined,
+      optimizable: undefined,
+      sortBy: 'name'
+    });
+  };
+
+  const getActiveFilterCount = () => {
+    let count = 0;
+    if (filters.searchTerm) count++;
+    if (filters.status) count++;
+    if (filters.category) count++;
+    if (filters.company) count++;
+    if (filters.frequency) count++;
+    if (filters.tags && filters.tags.length > 0) count++;
+    if (filters.needsMoreInfo !== undefined) count++;
+    if (filters.pinned !== undefined) count++;
+    if (filters.hasAdditionalFields !== undefined) count++;
+    if (filters.optimizable !== undefined) count++;
+    return count;
+  };
+
+  const activeFilterCount = getActiveFilterCount();
+
+  // Calculate stats
+  const activeContracts = contracts.filter(c => c.status === 'active');
+  const monthlySpend = contracts
+    .filter(c => c.status === 'active')
+    .reduce((total, contract) => {
+      switch (contract.frequency) {
+        case 'monthly': return total + contract.amount;
+        case 'quarterly': return total + (contract.amount / 3);
+        case 'yearly': return total + (contract.amount / 12);
+        case 'weekly': return total + (contract.amount * 4.33);
+        case 'bi-weekly': return total + (contract.amount * 2.17);
+        case 'one-time': return total + (contract.amount / 12);
+        default: return total;
+      }
+    }, 0);
+
+  // Tab change handler
+  const handleTabChange = (newTab: string) => {
+    setActiveTab(newTab);
+    // Reset filters when switching to advanced filters tab
+    if (newTab === 'filters') {
+      clearAllFilters();
+    }
+  };
+
+  // Helper function to get tab label and icon
+  const getTabContent = (tabType: string) => {
+    switch (tabType) {
+      case 'quickFilters':
+        return { icon: Tag, label: 'Quick Filters' };
+      case 'companies':
+        return { icon: Building2, label: 'Companies' };
+      case 'persons':
+        return { icon: User, label: 'Persons' };
+      case 'filters':
+        return { icon: TrendingUp, label: 'Advanced' };
+      default:
+        return { icon: Tag, label: tabType };
+    }
+  };
+
+  // Generate category stats
+  const generateCategoryStats = () => {
+    const categories = getCategories();
+    const categoryIcons: Record<string, React.ComponentType<any>> = {
+      subscription: Tag,
+      insurance: TrendingUp,
+      utilities: TrendingUp,
+      rent: Building2,
+      house: Building2,
+      services: Tag,
+      software: TrendingUp,
+      maintenance: TrendingUp,
+      other: Tag,
+      marketing: TrendingUp,
+      internet: Building2,
+      phone: Building2,
+      gym: Building2,
+      streaming: Building2,
+      transportation: Building2,
+      food: Building2,
+      entertainment: Building2,
+      education: Building2,
+      healthcare: Building2,
+      legal: Building2,
+    };
+
+    return categories.map(category => {
+      const count = contracts.filter(c => c.category === category).length;
+      const Icon = categoryIcons[category] || Tag;
+      const { color, bgColor } = getCategoryStatsColor(category);
+      
+      return {
+        title: category.charAt(0).toUpperCase() + category.slice(1),
+        value: count,
+        icon: Icon,
+        color,
+        bgColor,
+        clickable: count > 0,
+        filterType: 'category',
+        filterValue: category
+      };
+    });
+  };
+
+  // Generate family member stats
+  const generateFamilyMemberStats = () => {
+    const familyMembers = new Set<string>();
+    contracts.forEach(contract => {
+      if (contract.familyMember?.trim()) {
+        familyMembers.add(contract.familyMember.trim());
+      }
+    });
+
+    return Array.from(familyMembers)
+      .map(member => {
+        const count = contracts.filter(c => c.familyMember?.trim() === member).length;
+        return {
+          title: member,
+          value: count,
+          icon: User,
+          color: 'text-purple-600 dark:text-purple-400',
+          bgColor: 'bg-purple-100 dark:bg-purple-900/30',
+          clickable: count > 0,
+          filterType: 'familyMember',
+          filterValue: member
+        };
+      })
+      .sort((a, b) => (b.value as number) - (a.value as number));
+  };
+
+  // Generate company stats
+  const generateCompanyStats = () => {
+    const companies = new Set<string>();
+    contracts.forEach(contract => {
+      if (contract.company?.trim()) {
+        companies.add(contract.company.trim());
+      }
+    });
+
+    return Array.from(companies)
+      .map(company => {
+        const count = contracts.filter(c => c.company?.trim() === company).length;
+        return {
+          title: company,
+          value: count,
+          icon: Building2,
+          color: 'text-blue-600 dark:text-blue-400',
+          bgColor: 'bg-blue-100 dark:bg-blue-900/30',
+          clickable: count > 0,
+          filterType: 'company',
+          filterValue: company
+        };
+      })
+      .sort((a, b) => (b.value as number) - (a.value as number));
+  };
+
+  // Render category/company/person card
+  const renderFilterCard = (stat: any, index: number) => {
+    const isActive = filters && (
+      (stat.filterType === 'category' && filters.category === stat.filterValue) ||
+      (stat.filterType === 'familyMember' && filters.familyMember === stat.filterValue) ||
+      (stat.filterType === 'company' && filters.company === stat.filterValue)
+    );
+    
+    return (
+      <Card 
+        key={`${stat.filterType}-${index}`}
+        className={`bg-gradient-card border-border/50 hover:shadow-card transition-all duration-200 ${
+          stat.clickable ? 'cursor-pointer hover:scale-[1.02] border-primary/30 hover:border-primary/50' : ''
+        } ${isActive ? 'ring-2 ring-primary bg-primary/5 border-primary/50' : ''}`} 
+        onClick={stat.clickable ? () => updateFilter(stat.filterType, stat.filterValue) : undefined}
+      >
+        <CardContent className="p-2">
+          <div className="flex items-center gap-2">
+            <div className={`${stat.bgColor} p-1.5 rounded flex-shrink-0`}>
+              <stat.icon className={`h-3 w-3 ${stat.color}`} />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground truncate">
+                  {stat.title}
+                </span>
+                <span className="text-xs font-bold text-foreground ml-1">
+                  {stat.value}
+                </span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={setIsOpen}>
+      <SheetTrigger asChild>
+        <Button 
+          variant="secondary" 
+          size="icon" 
+          className="h-10 w-10 sm:h-12 sm:w-12 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 bg-background/80 backdrop-blur-sm border border-border hover:bg-background/90 hover:scale-105"
+        >
+          <Menu className="h-5 w-5" />
+          <span className="sr-only">Open menu</span>
+        </Button>
+      </SheetTrigger>
+      <SheetPortal>
+        <SheetOverlay className="bg-black/10 backdrop-blur-[1px]" />
+        <SheetContent 
+          side="left" 
+          className="w-[90vw] max-w-[400px] sm:w-[500px] overflow-y-auto"
+        >
+          <SheetHeader className="pb-4">
+            <SheetTitle className="text-left">
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-bold">{appConfig.name}</h1>
+              </div>
+              {/* Overview Stats */}
+              <div className="flex flex-wrap items-center gap-4 mt-3 text-sm text-muted-foreground">
+                <div className="flex items-center gap-1.5">
+                  <div className="w-2 h-2 bg-green-400 rounded-full"></div>
+                  <span>Total: {contracts.length}</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="w-2 h-2 bg-blue-400 rounded-full"></div>
+                  <span>Active: {activeContracts.length}</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="w-2 h-2 bg-purple-400 rounded-full"></div>
+                  <span>Monthly: ${monthlySpend.toFixed(0)}</span>
+                </div>
+              </div>
+            </SheetTitle>
+          </SheetHeader>
+
+        <div className="space-y-6">
+          {/* Add Contract Button */}
+          <div className="space-y-3">
+            <Button onClick={onAddContract} size="lg" className="w-full bg-primary hover:bg-primary/90">
+              <Plus className="h-5 w-5 mr-2" />
+              Add Contract
+            </Button>
+          </div>
+
+          <Separator />
+
+          {/* Search Section */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold">Search</h3>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                ref={searchInputRef}
+                placeholder="Search contracts..."
+                value={filters.searchTerm || ''}
+                onChange={(e) => updateFilter('searchTerm', e.target.value)}
+                className="pl-10"
+              />
+              {filters.searchTerm && (
+                <button
+                  onClick={() => updateFilter('searchTerm', '')}
+                  className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground hover:text-foreground transition-colors"
+                  title="Clear search"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+          </div>
+
+          <Separator />
+
+          {/* Quick Filter Tabs */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold">Quick Filters</h3>
+            <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
+              <TabsList className="grid w-full grid-cols-4">
+                <TabsTrigger value="quickFilters" className="text-xs flex items-center gap-1">
+                  <Tag className="h-3 w-3" />
+                  <span className="hidden sm:inline">Quick</span>
+                </TabsTrigger>
+                <TabsTrigger value="companies" className="text-xs flex items-center gap-1">
+                  <Building2 className="h-3 w-3" />
+                  <span className="hidden sm:inline">Company</span>
+                </TabsTrigger>
+                <TabsTrigger value="persons" className="text-xs flex items-center gap-1">
+                  <User className="h-3 w-3" />
+                  <span className="hidden sm:inline">Person</span>
+                </TabsTrigger>
+                <TabsTrigger value="filters" className="text-xs flex items-center gap-1">
+                  <TrendingUp className="h-3 w-3" />
+                  <span className="hidden sm:inline">Advanced</span>
+                </TabsTrigger>
+              </TabsList>
+              
+              <TabsContent value="quickFilters" className="space-y-3 mt-3">
+                {/* Quick Filter - Categories Only */}
+                <div className="p-3 bg-muted/10 rounded-lg border border-border/30">
+                  <div className="flex items-center justify-between mb-2">
+                    <h4 className="text-xs font-medium text-foreground">Filter by Category</h4>
+                    <span className="text-xs text-muted-foreground">Click to filter</span>
+                  </div>
+                  
+                  {/* Categories Only */}
+                  <div className="grid grid-cols-2 gap-2">
+                    {generateCategoryStats()
+                      .filter(stat => typeof stat.value === 'number' && stat.value > 0)
+                      .sort((a, b) => (b.value as number) - (a.value as number))
+                      .map((stat, index) => renderFilterCard(stat, index))}
+                  </div>
+                </div>
+              </TabsContent>
+              
+              <TabsContent value="companies" className="space-y-3 mt-3">
+                {/* Company Filter */}
+                <div className="p-3 bg-muted/10 rounded-lg border border-border/30">
+                  <div className="flex items-center justify-between mb-2">
+                    <h4 className="text-xs font-medium text-foreground">Filter by Company</h4>
+                    <span className="text-xs text-muted-foreground">Click to filter</span>
+                  </div>
+                  
+                  {/* Company Filter Buttons */}
+                  <div className="grid grid-cols-2 gap-2">
+                    {generateCompanyStats().map((stat, index) => renderFilterCard(stat, index))}
+                  </div>
+                </div>
+              </TabsContent>
+              
+              <TabsContent value="persons" className="space-y-3 mt-3">
+                {/* Person Filter */}
+                <div className="p-3 bg-muted/10 rounded-lg border border-border/30">
+                  <div className="flex items-center justify-between mb-2">
+                    <h4 className="text-xs font-medium text-foreground">Filter by Person</h4>
+                    <span className="text-xs text-muted-foreground">Click to filter</span>
+                  </div>
+                  
+                  {/* Person Filter Buttons */}
+                  <div className="grid grid-cols-2 gap-2">
+                    {generateFamilyMemberStats().map((stat, index) => renderFilterCard(stat, index))}
+                  </div>
+                </div>
+              </TabsContent>
+              
+              <TabsContent value="filters" className="space-y-3 mt-3">
+                {/* Advanced Filters Section */}
+                <div className="w-full">
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <h4 className="text-xs font-medium text-foreground">Advanced Filters</h4>
+                      {activeFilterCount > 0 && (
+                        <Button variant="ghost" size="sm" onClick={clearAllFilters} className="text-muted-foreground h-6 text-xs">
+                          <X className="h-3 w-3 mr-1" />
+                          Clear All ({activeFilterCount})
+                        </Button>
+                      )}
+                    </div>
+
+                    {/* Core Filters */}
+                    <div className="space-y-3">
+                      <div>
+                        <Label htmlFor="status-filter" className="text-xs font-medium">Status</Label>
+                        <Select value={filters.status || 'all'} onValueChange={(value) => updateFilter('status', value === 'all' ? undefined : value)}>
+                          <SelectTrigger id="status-filter" className="w-full h-8 text-xs">
+                            <SelectValue placeholder="All Statuses" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Statuses</SelectItem>
+                            {getStatuses().map(status => (
+                              <SelectItem key={status} value={status}>
+                                {getStatusDisplayName(status)}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div>
+                        <Label htmlFor="category-filter" className="text-xs font-medium">Category</Label>
+                        <Select value={filters.category || 'all'} onValueChange={(value) => updateFilter('category', value === 'all' ? undefined : value)}>
+                          <SelectTrigger id="category-filter" className="w-full h-8 text-xs">
+                            <SelectValue placeholder="All Categories" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Categories</SelectItem>
+                            {getCategories().map(category => (
+                              <SelectItem key={category} value={category}>
+                                {getCategoryDisplayName(category)}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div>
+                        <Label htmlFor="company-filter" className="text-xs font-medium">Company</Label>
+                        <Select value={filters.company || 'all'} onValueChange={(value) => updateFilter('company', value === 'all' ? undefined : value)}>
+                          <SelectTrigger id="company-filter" className="w-full h-8 text-xs">
+                            <SelectValue placeholder="All Companies" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Companies</SelectItem>
+                            {existingContracts && Array.from(new Set(existingContracts.map(c => c.company).filter(Boolean))).sort().map(company => (
+                              <SelectItem key={company} value={company}>
+                                {company}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div>
+                        <Label htmlFor="frequency-filter" className="text-xs font-medium">Frequency</Label>
+                        <Select value={filters.frequency || 'all'} onValueChange={(value) => updateFilter('frequency', value === 'all' ? undefined : value)}>
+                          <SelectTrigger id="frequency-filter" className="w-full h-8 text-xs">
+                            <SelectValue placeholder="All Frequencies" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Frequencies</SelectItem>
+                            {getFrequencies().map(frequency => (
+                              <SelectItem key={frequency} value={frequency}>
+                                {getFrequencyDisplayName(frequency)}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div>
+                        <Label htmlFor="needs-more-info-filter" className="text-xs font-medium">Contract Status</Label>
+                        <Select value={(() => {
+                          if (filters.needsMoreInfo === true) return 'true';
+                          if (filters.optimizable === true) return 'optimizable';
+                          if (filters.needsMoreInfo === false) return 'false';
+                          return 'all';
+                        })()} onValueChange={(value) => {
+                          if (value === 'all') {
+                            const newFilters = { ...filters, needsMoreInfo: undefined, optimizable: undefined };
+                            onFiltersChange(newFilters);
+                          } else if (value === 'true') {
+                            const newFilters = { ...filters, needsMoreInfo: true, optimizable: undefined };
+                            onFiltersChange(newFilters);
+                          } else if (value === 'false') {
+                            const newFilters = { ...filters, needsMoreInfo: false, optimizable: undefined };
+                            onFiltersChange(newFilters);
+                          } else if (value === 'optimizable') {
+                            const newFilters = { ...filters, needsMoreInfo: undefined, optimizable: true };
+                            onFiltersChange(newFilters);
+                          }
+                        }}>
+                          <SelectTrigger id="needs-more-info-filter" className="w-full h-8 text-xs">
+                            <SelectValue placeholder="All Contracts" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Contracts</SelectItem>
+                            <SelectItem value="true">Needs Attention</SelectItem>
+                            <SelectItem value="false">Complete</SelectItem>
+                            <SelectItem value="optimizable">Needs Optimization</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div>
+                        <Label htmlFor="pinned-filter" className="text-xs font-medium">Pinned</Label>
+                        <Select value={filters.pinned === undefined ? 'all' : filters.pinned.toString()} onValueChange={(value) => updateFilter('pinned', value === 'all' ? undefined : value === 'true')}>
+                          <SelectTrigger id="pinned-filter" className="w-full h-8 text-xs">
+                            <SelectValue placeholder="All Contracts" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Contracts</SelectItem>
+                            <SelectItem value="true">Pinned Only</SelectItem>
+                            <SelectItem value="false">Not Pinned</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div>
+                        <Label htmlFor="additional-fields-filter" className="text-xs font-medium">Additional Fields</Label>
+                        <Select value={filters.hasAdditionalFields === undefined ? 'all' : filters.hasAdditionalFields.toString()} onValueChange={(value) => updateFilter('hasAdditionalFields', value === 'all' ? undefined : value === 'true')}>
+                          <SelectTrigger id="additional-fields-filter" className="w-full h-8 text-xs">
+                            <SelectValue placeholder="All Contracts" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Contracts</SelectItem>
+                            <SelectItem value="true">With Additional Fields</SelectItem>
+                            <SelectItem value="false">No Additional Fields</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div>
+                        <Label htmlFor="tags-filter" className="text-xs font-medium">Tags</Label>
+                        <Select value={filters.tags?.[0] || 'all'} onValueChange={(value) => updateFilter('tags', value === 'all' ? undefined : [value])}>
+                          <SelectTrigger id="tags-filter" className="w-full h-8 text-xs">
+                            <SelectValue placeholder="All Tags" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="all">All Tags</SelectItem>
+                            {availableTags.map(tag => (
+                              <SelectItem key={tag} value={tag}>
+                                {tag}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </TabsContent>
+            </Tabs>
+          </div>
+
+          <Separator />
+
+          {/* Quick Actions */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold">Quick Actions</h3>
+            <div className="grid grid-cols-2 gap-2">
+              <Button variant="outline" onClick={onExport} size="sm" className="w-full">
+                <Download className="h-4 w-4 mr-2" />
+                Export
+              </Button>
+              <Button variant="outline" onClick={onImport} size="sm" className="w-full">
+                <Upload className="h-4 w-4 mr-2" />
+                Import
+              </Button>
+              <Button variant="outline" size="sm" className="w-full">
+                <Settings className="h-4 w-4 mr-2" />
+                Settings
+              </Button>
+            </div>
+          </div>
+
+          <Separator />
+
+          {/* Theme Toggle */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold">Appearance</h3>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Theme</span>
+              <ThemeToggle />
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+      </SheetPortal>
+    </Sheet>
+  );
+};

--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -53,7 +53,7 @@ export function ThemeToggle() {
               <Button 
                 variant="outline" 
                 size="sm" 
-                className="h-9 w-9 p-0 bg-white/20 border-white/30 text-white hover:bg-white/30 hover:border-white/50 shadow-sm"
+                className="h-9 w-9 p-0 bg-background border-border text-foreground hover:bg-accent hover:border-accent-foreground shadow-sm"
               >
                 {getIcon()}
                 <span className="sr-only">Toggle theme</span>
@@ -109,7 +109,7 @@ export function ThemeToggleSimple() {
             variant="outline"
             size="sm"
             onClick={toggle}
-            className="h-9 w-9 p-0 bg-white/20 border-white/30 text-white hover:bg-white/30 hover:border-white/50 shadow-sm"
+            className="h-9 w-9 p-0 bg-background border-border text-foreground hover:bg-accent hover:border-accent-foreground shadow-sm"
           >
             {resolvedTheme === 'dark' ? (
               <Sun className="h-4 w-4" />

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -4,30 +4,22 @@ import { Contract, ContractFilters as FilterType } from '@/types/contract';
 import { useContractStorage } from '@/hooks/useContractStorage';
 import { ContractCard } from '@/components/ContractCard';
 import { ContractForm } from '@/components/ContractForm';
+import { SlideInMenu } from '@/components/SlideInMenu';
 
-import { ContractStats } from '@/components/ContractStats';
 import { NotificationBanner } from '@/components/NotificationBanner';
 
-
-import { ThemeToggle } from '@/components/ThemeToggle';
-
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { 
   Plus, 
-  Download, 
-  Upload, 
   Loader2,
   FileText,
   AlertTriangle,
-  Search,
-  X,
-  Info
+  Info,
+  X
 } from 'lucide-react';
 import { appConfig } from '@/config/app';
 import { calculateNextThreePayments } from '@/lib/paymentCalculator';
@@ -121,22 +113,27 @@ const Index = () => {
 
   // Store current filter state in URL for navigation context
   useEffect(() => {
-    const params = new URLSearchParams();
-    if (filters.status) params.set('status', filters.status);
-    if (filters.category) params.set('category', filters.category);
-    if (filters.familyMember) params.set('familyMember', filters.familyMember);
-    if (filters.company) params.set('company', filters.company);
-    if (filters.frequency) params.set('frequency', filters.frequency);
-    if (filters.tags?.length) params.set('tags', filters.tags.join(','));
-    if (filters.needsMoreInfo !== undefined) params.set('needsMoreInfo', filters.needsMoreInfo.toString());
-    if (filters.pinned !== undefined) params.set('pinned', filters.pinned.toString());
-    if (filters.hasAdditionalFields !== undefined) params.set('hasAdditionalFields', filters.hasAdditionalFields.toString());
-    if (filters.searchTerm) params.set('search', filters.searchTerm);
-    if (filters.sortBy) params.set('sortBy', filters.sortBy);
-    if (filters.sortOrder) params.set('sortOrder', filters.sortOrder);
-    
-    // Use setSearchParams to properly update React Router's search params state
-    setSearchParams(params);
+    // Debounce URL updates to prevent too many calls
+    const timeoutId = setTimeout(() => {
+      const params = new URLSearchParams();
+      if (filters.status) params.set('status', filters.status);
+      if (filters.category) params.set('category', filters.category);
+      if (filters.familyMember) params.set('familyMember', filters.familyMember);
+      if (filters.company) params.set('company', filters.company);
+      if (filters.frequency) params.set('frequency', filters.frequency);
+      if (filters.tags?.length) params.set('tags', filters.tags.join(','));
+      if (filters.needsMoreInfo !== undefined) params.set('needsMoreInfo', filters.needsMoreInfo.toString());
+      if (filters.pinned !== undefined) params.set('pinned', filters.pinned.toString());
+      if (filters.hasAdditionalFields !== undefined) params.set('hasAdditionalFields', filters.hasAdditionalFields.toString());
+      if (filters.searchTerm) params.set('search', filters.searchTerm);
+      if (filters.sortBy) params.set('sortBy', filters.sortBy);
+      if (filters.sortOrder) params.set('sortOrder', filters.sortOrder);
+      
+      // Use setSearchParams to properly update React Router's search params state
+      setSearchParams(params);
+    }, 300); // 300ms debounce
+
+    return () => clearTimeout(timeoutId);
   }, [filters, setSearchParams]);
 
   // Filter and sort contracts based on current filters
@@ -465,172 +462,70 @@ const Index = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      <div className="bg-black text-white border-b border-gray-700 shadow-sm">
-        <div className="container mx-auto px-4 py-4 sm:py-6">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div>
-              <h1 className="text-2xl sm:text-3xl font-bold">{appConfig.name}</h1>
-              
-              {/* Overview Stats */}
-              <div className="flex flex-wrap items-center gap-4 mt-2 text-xs sm:text-sm">
-                {(() => {
-                  // Generate the same stats that were in ContractStats
-                  const activeContracts = contracts.filter(c => c.status === 'active');
-                  const monthlySpend = contracts
-                    .filter(c => c.status === 'active')
-                    .reduce((total, contract) => {
-                      switch (contract.frequency) {
-                        case 'monthly': return total + contract.amount;
-                        case 'quarterly': return total + (contract.amount / 3);
-                        case 'yearly': return total + (contract.amount / 12);
-                        case 'weekly': return total + (contract.amount * 4.33);
-                        case 'bi-weekly': return total + (contract.amount * 2.17);
-                        case 'one-time': return total + (contract.amount / 12);
-                        default: return total;
-                      }
-                    }, 0);
-                  
-                  return (
-                    <>
-                      <div className="flex items-center gap-1.5">
-                        <div className="w-2 h-2 bg-green-400 rounded-full"></div>
-                        <span className="text-primary-foreground/70">Total:</span>
-                        <span className="text-white font-medium">{contracts.length}</span>
-                      </div>
-                      <div className="flex items-center gap-1.5">
-                        <div className="w-2 h-2 bg-blue-400 rounded-full"></div>
-                        <span className="text-primary-foreground/70">Active:</span>
-                        <span className="text-white font-medium">{activeContracts.length}</span>
-                      </div>
-                      <div className="flex items-center gap-1.5">
-                        <div className="w-2 h-2 bg-purple-400 rounded-full"></div>
-                        <span className="text-primary-foreground/70">Monthly:</span>
-                        <span className="text-white font-medium">${monthlySpend.toFixed(0)}</span>
-                      </div>
-                    </>
-                  );
-                })()}
-              </div>
-            </div>
-            <div className="flex flex-wrap items-center gap-2 sm:gap-4">
-              {/* Search Input */}
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-white/60" />
-                <Input
-                  ref={searchInputRef}
-                  placeholder="Search contracts..."
-                  value={filters.searchTerm || ''}
-                  onChange={(e) => setFilters(prev => ({ ...prev, searchTerm: e.target.value }))}
-                  className="pl-10 w-64 bg-white/10 border-white/20 text-white placeholder:text-white/60 focus:bg-white/20 transition-all duration-200 hover:bg-white/15 focus:bg-white/20"
-                />
-                {filters.searchTerm && (
-                  <button
-                    onClick={() => setFilters(prev => ({ ...prev, searchTerm: '' }))}
-                    className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-white/60 hover:text-white transition-colors"
-                    title="Clear search"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
-                )}
-              </div>
-              
-              {/* Sort Dropdown */}
-              <Select value={filters.sortBy || 'name'} onValueChange={(value) => {
-                const newSortBy = value as any;
-                const newSortOrder = (newSortBy === 'updatedAt' || newSortBy === 'createdAt' || newSortBy === 'nextPaymentDate') ? 'desc' : 'asc';
-                setFilters(prev => ({ ...prev, sortBy: newSortBy, sortOrder: newSortOrder }));
-              }}>
-                <SelectTrigger className="w-32 bg-white/10 border-white/20 text-white hover:bg-white/15 hover:border-white/30 transition-all duration-200">
-                  <SelectValue placeholder="Sort by" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="name">Name</SelectItem>
-                  <SelectItem value="amount">Amount</SelectItem>
-                  <SelectItem value="nextPaymentDate">Next Payment</SelectItem>
-                  <SelectItem value="createdAt">Created Date</SelectItem>
-                  <SelectItem value="updatedAt">Last Updated</SelectItem>
-                </SelectContent>
-              </Select>
-
-
-
-              <Button
-                variant="secondary"
-                onClick={exportContracts}
-                size="sm"
-                className="bg-white/10 text-white border-white/20 hover:bg-white/20 hover:border-white/30 text-xs sm:text-sm transition-all duration-200"
-              >
-                <Download className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
-                Export
-              </Button>
-              <Button 
-                variant="secondary" 
-                size="sm"
-                className="bg-white/10 text-white border-white/20 hover:bg-white/30 hover:border-white/40 transition-all duration-200 text-xs sm:text-sm"
-                onClick={() => document.getElementById('file-upload')?.click()}
-              >
-                <input
-                  type="file"
-                  accept=".json"
-                  onChange={handleFileUpload}
-                  className="hidden"
-                  id="file-upload"
-                />
-                <Upload className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
-                Import
-              </Button>
-              <ThemeToggle />
-              <Dialog open={isFormOpen} onOpenChange={handleDialogClose}>
-                <DialogTrigger asChild>
-                  <Button onClick={openAddForm} size="sm" className="bg-primary-foreground text-primary hover:bg-primary-foreground/90 hover:scale-105 text-xs sm:text-sm transition-all duration-200">
-                    <Plus className="h-3 w-3 sm:h-4 sm:w-4 mr-1 sm:mr-2" />
-                    Add Contract
-                  </Button>
-                </DialogTrigger>
-                <DialogContent className="max-w-6xl w-[95vw] max-h-[90vh] overflow-y-auto scrollbar-thin">
-                  <DialogHeader>
-                    <DialogTitle>
-                      {editingContract && editingContract.id ? 'Edit Contract' : editingContract ? 'Copy Contract' : 'Add New Contract'}
-                    </DialogTitle>
-                  </DialogHeader>
-                  <ContractForm
-                    contract={editingContract}
-                    isCopying={isCopying}
-                    existingContracts={contracts}
-                    onSubmit={editingContract && editingContract.id ? handleEditContract : handleAddContract}
-                    onCancel={() => handleDialogClose(false)}
-                    onDirtyStateChange={setIsFormDirty}
-                  />
-                </DialogContent>
-              </Dialog>
-
-              {/* Unsaved Changes Confirmation Dialog */}
-              <AlertDialog open={showUnsavedChangesDialog} onOpenChange={setShowUnsavedChangesDialog}>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      You have unsaved changes in the form. Are you sure you want to close without saving? All changes will be lost.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel onClick={handleUnsavedChangesCancel}>
-                      Continue Editing
-                    </AlertDialogCancel>
-                    <AlertDialogAction 
-                      onClick={handleUnsavedChangesConfirm}
-                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                    >
-                      Discard Changes
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            </div>
-          </div>
-        </div>
+      {/* Floating Menu Button */}
+      <div className="fixed top-4 left-4 sm:top-8 sm:left-4 z-50">
+        <SlideInMenu
+          filters={filters}
+          onFiltersChange={setFilters}
+          availableTags={availableTags}
+          existingContracts={contracts}
+          onExport={exportContracts}
+          onImport={() => document.getElementById('file-upload')?.click()}
+          onAddContract={openAddForm}
+          contracts={contracts}
+        />
       </div>
+
+      {/* Hidden file input for import */}
+      <input
+        type="file"
+        accept=".json"
+        onChange={handleFileUpload}
+        className="hidden"
+        id="file-upload"
+      />
+      
+      {/* Add Contract Dialog */}
+      <Dialog open={isFormOpen} onOpenChange={handleDialogClose}>
+        <DialogContent className="max-w-6xl w-[95vw] max-h-[90vh] overflow-y-auto scrollbar-thin">
+          <DialogHeader>
+            <DialogTitle>
+              {editingContract && editingContract.id ? 'Edit Contract' : editingContract ? 'Copy Contract' : 'Add New Contract'}
+            </DialogTitle>
+          </DialogHeader>
+          <ContractForm
+            contract={editingContract}
+            isCopying={isCopying}
+            existingContracts={contracts}
+            onSubmit={editingContract && editingContract.id ? handleEditContract : handleAddContract}
+            onCancel={() => handleDialogClose(false)}
+            onDirtyStateChange={setIsFormDirty}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Unsaved Changes Confirmation Dialog */}
+      <AlertDialog open={showUnsavedChangesDialog} onOpenChange={setShowUnsavedChangesDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
+          <AlertDialogDescription>
+            You have unsaved changes in the form. Are you sure you want to close without saving? All changes will be lost.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleUnsavedChangesCancel}>
+            Continue Editing
+          </AlertDialogCancel>
+          <AlertDialogAction 
+            onClick={handleUnsavedChangesConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Discard Changes
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
 
       <div className="container mx-auto px-4 py-6 sm:py-8">
         {/* Demo Mode Banner */}
@@ -646,10 +541,22 @@ const Index = () => {
         )}
         
         {/* Active Filters Display */}
-        {(filters.status || filters.category || filters.company || filters.familyMember || filters.frequency || filters.tags?.length || filters.needsMoreInfo !== undefined || filters.pinned !== undefined || filters.hasAdditionalFields !== undefined || filters.dataQualityGrade) && (
+        {(filters.searchTerm || filters.status || filters.category || filters.company || filters.familyMember || filters.frequency || filters.tags?.length || filters.needsMoreInfo !== undefined || filters.pinned !== undefined || filters.hasAdditionalFields !== undefined || filters.dataQualityGrade) && (
           <div className="flex items-center gap-2 text-sm mb-6">
             <span className="text-muted-foreground font-medium">Active Filters:</span>
             <div className="flex flex-wrap items-center gap-2">
+              {filters.searchTerm && (
+                <div className="flex items-center gap-1 px-2 py-1 bg-[#01A5E1]/10 text-[#01A5E1] rounded-md border border-[#01A5E1]/20">
+                  <span className="text-xs font-medium">Search: {filters.searchTerm}</span>
+                  <button
+                    onClick={() => setFilters(prev => ({ ...prev, searchTerm: '' }))}
+                    className="ml-1 text-[#01A5E1]/70 hover:text-[#01A5E1] transition-colors"
+                    title="Clear search"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              )}
               {filters.status && (
                 <div className="flex items-center gap-1 px-2 py-1 bg-[#A7E459]/10 text-[#A7E459] rounded-md border border-[#A7E459]/20">
                   <span className="text-xs font-medium">Status: {filters.status}</span>
@@ -791,147 +698,7 @@ const Index = () => {
           </div>
         )}
 
-        {/* Statistics */}
-        <ContractStats 
-          contracts={contracts} 
-          onFilter={(filterType, value) => {
-            if (filterType === 'reset') {
-              // Reset all filters when switching tabs
-              setFilters({
-                searchTerm: '',
-                sortBy: 'updatedAt',
-                sortOrder: 'desc'
-              });
-            } else if (filterType === 'viewMode') {
-              // Handle view mode as mutually exclusive options
-              if (value === 'all') {
-                // Reset all filters to show all contracts
-                setFilters(prev => ({ 
-                  ...prev,
-                  status: undefined,
-                  needsMoreInfo: undefined,
-                  searchTerm: ''
-                }));
-              } else if (value === 'active') {
-                // Show only active contracts
-                setFilters(prev => ({ 
-                  ...prev,
-                  status: 'active',
-                  needsMoreInfo: undefined,
-                  searchTerm: ''
-                }));
-              } else if (value === 'needsAttention') {
-                // Show only contracts that need attention
-                setFilters(prev => ({ 
-                  ...prev,
-                  status: undefined,
-                  needsMoreInfo: true,
-                  searchTerm: ''
-                }));
-              }
-            } else if (filterType === 'category') {
-              // If clicking the same category filter, reset it
-              if (filters.category === value) {
-                setFilters(prev => ({ ...prev, category: undefined, searchTerm: '' }));
-              } else {
-                // Clear search when applying a category filter
-                setFilters(prev => ({ 
-                  ...prev,
-                  category: value as Contract['category'],
-                  searchTerm: '' // Clear search when filtering
-                }));
-              }
-            } else if (filterType === 'familyMember') {
-              // If clicking the same family member filter, reset it
-              if (filters.familyMember === value) {
-                setFilters(prev => ({ ...prev, familyMember: undefined, searchTerm: '' }));
-              } else {
-                // Clear search when applying a family member filter
-                setFilters(prev => ({ 
-                  ...prev,
-                  familyMember: value,
-                  searchTerm: '' // Clear search when filtering
-                }));
-              }
-            } else if (filterType === 'company') {
-              // If clicking the same company filter, reset it
-              if (filters.company === value) {
-                setFilters(prev => ({ ...prev, company: undefined, searchTerm: '' }));
-              } else {
-                // Clear search when applying a company filter
-                setFilters(prev => ({ 
-                  ...prev,
-                  company: value,
-                  searchTerm: '' // Clear search when filtering
-                }));
-              }
-            } else if (filterType === 'tags') {
-              // If clicking the same tag filter, reset it
-              if (filters.tags?.includes(value)) {
-                setFilters(prev => ({ ...prev, tags: undefined, searchTerm: '' }));
-              } else {
-                // Clear search when applying a tag filter
-                setFilters(prev => ({ 
-                  ...prev,
-                  tags: [value],
-                  searchTerm: '' // Clear search when filtering
-                }));
-              }
-            } else if (filterType === 'pinned') {
-              // If clicking the same pinned filter, reset it
-              if (filters.pinned === (value === 'true')) {
-                setFilters(prev => ({ ...prev, pinned: undefined, searchTerm: '' }));
-              } else {
-                // Clear search when applying a pinned filter
-                setFilters(prev => ({ 
-                  ...prev,
-                  pinned: value === 'true',
-                  searchTerm: '' // Clear search when filtering
-                }));
-              }
-            } else if (filterType === 'hasAdditionalFields') {
-              // If clicking the same hasAdditionalFields filter, reset it
-              if (filters.hasAdditionalFields === (value === 'true')) {
-                setFilters(prev => ({ ...prev, hasAdditionalFields: undefined, searchTerm: '' }));
-              } else {
-                // Clear search when applying a hasAdditionalFields filter
-                setFilters(prev => ({ 
-                  ...prev,
-                  hasAdditionalFields: value === 'true',
-                  searchTerm: '' // Clear search when filtering
-                }));
-              }
-            } else if (filterType === 'invalidCategories') {
-              // Filter to show only contracts with invalid categories
-              const invalidCategoryContracts = contracts.filter(contract => !isValidCategory(contract.category));
-              const invalidCategories = [...new Set(invalidCategoryContracts.map(c => c.category))];
-              setFilters(prev => ({ 
-                ...prev,
-                searchTerm: invalidCategories.join(' '),
-                category: undefined,
-                status: undefined,
-                tags: undefined,
-                needsMoreInfo: undefined,
-                pinned: undefined,
-                hasAdditionalFields: undefined
-              }));
-            }
-          }}
-          activeFilters={{
-            status: filters.status,
-            category: filters.category,
-            familyMember: filters.familyMember,
-            company: filters.company,
-            needsMoreInfo: filters.needsMoreInfo,
-            pinned: filters.pinned,
-            optimizable: filters.optimizable,
-            hasAdditionalFields: filters.hasAdditionalFields
-          }}
-          filters={filters}
-          onFiltersChange={setFilters}
-          availableTags={availableTags}
-          filteredContracts={filteredContracts}
-        />
+
 
         {/* Notifications */}
         <NotificationBanner contracts={contracts} onEdit={scrollToContract} />


### PR DESCRIPTION
- Show text search as a removable pill in Active Filters
- Clean up Ctrl+F handler (no debug logs); opens menu when closed, defers to browser when open
- Make floating menu button responsive (mobile size/spacing) and adjust sheet width on small screens
- Increase top colorful bar height and add spacing from the floating button
- Move “Add Contract” above search in menu; remove duplicate separators
- Collapse Upcoming Payments and Expired Contracts by default
- Lighten sheet overlay; fix theme toggle visibility across themes